### PR TITLE
Fix agents field in plugin.json to use array format

### DIFF
--- a/plugins/homunculus/.claude-plugin/plugin.json
+++ b/plugins/homunculus/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "keywords": ["ai", "evolution", "living", "homunculus", "alchemy", "self-evolving", "instincts"],
   "commands": "./commands/",
-  "agents": "./agents/",
+  "agents": ["./agents/observer.md"],
   "skills": "./skills/",
   "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
## Summary
- Fixed the `agents` field in `plugin.json` to use the correct array format
- Changed from `"./agents/"` (directory path string) to `["./agents/observer.md"]` (explicit file array)

This resolves the validation error that prevents plugin installation in Claude Code 2.1.17+.

## Test plan
- [ ] Install the plugin with `claude plugin install homunculus@homunculus`
- [ ] Verify installation succeeds without validation errors

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)