### PR TITLE
feat: add Windows/PowerShell support

### DIFF
--- a/plugins/homunculus/hooks/hooks.json
+++ b/plugins/homunculus/hooks/hooks.json
@@ -5,8 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/observe.sh prompt",
-            "timeout": 3
+            "command": "sh -c 'if [ \"$(uname -o 2>/dev/null)\" = \"Msys\" ] || [ \"$(uname -o 2>/dev/null)\" = \"Cygwin\" ]; then powershell -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/scripts/observe.ps1\" prompt; else \"${CLAUDE_PLUGIN_ROOT}/scripts/observe.sh\" prompt; fi'",
+            "timeout": 5
           }
         ]
       }
@@ -17,8 +17,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/observe.sh tool",
-            "timeout": 3
+            "command": "sh -c 'if [ \"$(uname -o 2>/dev/null)\" = \"Msys\" ] || [ \"$(uname -o 2>/dev/null)\" = \"Cygwin\" ]; then powershell -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/scripts/observe.ps1\" tool; else \"${CLAUDE_PLUGIN_ROOT}/scripts/observe.sh\" tool; fi'",
+            "timeout": 5
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on_stop.sh",
+            "command": "sh -c 'if [ \"$(uname -o 2>/dev/null)\" = \"Msys\" ] || [ \"$(uname -o 2>/dev/null)\" = \"Cygwin\" ]; then powershell -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/scripts/on_stop.ps1\"; else \"${CLAUDE_PLUGIN_ROOT}/scripts/on_stop.sh\"; fi'",
             "timeout": 10
           }
         ]

--- a/plugins/homunculus/scripts/observe.ps1
+++ b/plugins/homunculus/scripts/observe.ps1
@@ -1,0 +1,105 @@
+# Homunculus v2 Observation Capture (PowerShell)
+# Append-only, non-blocking. Never fails (exit 0 always).
+
+param(
+    [string]$EventType = "unknown"
+)
+
+$OBS_FILE = ".claude/homunculus/observations.jsonl"
+
+# Ensure directory exists
+$obsDir = Split-Path -Parent $OBS_FILE
+if (-not (Test-Path $obsDir)) {
+    New-Item -ItemType Directory -Path $obsDir -Force | Out-Null
+}
+
+# Read input from stdin (hook data as JSON)
+$InputData = $null
+try {
+    $InputData = [Console]::In.ReadToEnd()
+} catch {
+    $InputData = ""
+}
+
+# Get timestamp (UTC ISO 8601)
+$Timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+# Parse input JSON
+$InputObj = $null
+try {
+    if ($InputData) {
+        $InputObj = $InputData | ConvertFrom-Json -ErrorAction SilentlyContinue
+    }
+} catch {
+    $InputObj = $null
+}
+
+# Build observation JSON based on event type
+switch ($EventType) {
+    "prompt" {
+        $Prompt = ""
+        if ($InputObj -and $InputObj.prompt) {
+            $Prompt = $InputObj.prompt
+        }
+        if ($Prompt) {
+            if ($Prompt.Length -gt 500) {
+                $Prompt = $Prompt.Substring(0, 500)
+            }
+            $obs = @{
+                timestamp = $Timestamp
+                type = "prompt"
+                prompt = $Prompt
+            } | ConvertTo-Json -Compress
+            Add-Content -Path $OBS_FILE -Value $obs -ErrorAction SilentlyContinue
+        }
+    }
+    "tool" {
+        $ToolName = ""
+        $ToolInput = @{}
+        $ToolResponse = ""
+
+        if ($InputObj) {
+            if ($InputObj.tool_name) { $ToolName = $InputObj.tool_name }
+            if ($InputObj.tool_input) { $ToolInput = $InputObj.tool_input }
+            if ($InputObj.tool_response) {
+                $ToolResponse = $InputObj.tool_response | ConvertTo-Json -Compress -ErrorAction SilentlyContinue
+                if (-not $ToolResponse) { $ToolResponse = "{}" }
+            }
+        }
+
+        if ($ToolName) {
+            if ($ToolResponse.Length -gt 1000) {
+                $ToolResponse = $ToolResponse.Substring(0, 1000)
+            }
+            try {
+                $obs = @{
+                    timestamp = $Timestamp
+                    type = "tool"
+                    tool = $ToolName
+                    input = $ToolInput
+                    response = $ToolResponse
+                } | ConvertTo-Json -Compress
+                Add-Content -Path $OBS_FILE -Value $obs -ErrorAction SilentlyContinue
+            } catch {
+                $obs = @{
+                    timestamp = $Timestamp
+                    type = "tool"
+                    tool = $ToolName
+                } | ConvertTo-Json -Compress
+                Add-Content -Path $OBS_FILE -Value $obs -ErrorAction SilentlyContinue
+            }
+        }
+    }
+    default {
+        try {
+            $obs = @{
+                timestamp = $Timestamp
+                type = $EventType
+                raw = $InputData
+            } | ConvertTo-Json -Compress
+            Add-Content -Path $OBS_FILE -Value $obs -ErrorAction SilentlyContinue
+        } catch {}
+    }
+}
+
+exit 0

--- a/plugins/homunculus/scripts/on_stop.ps1
+++ b/plugins/homunculus/scripts/on_stop.ps1
@@ -1,0 +1,40 @@
+# Homunculus v2 Stop Hook (PowerShell)
+# Updates session count
+
+$STATE = ".claude/homunculus/identity.json"
+$PENDING_DIR = ".claude/homunculus/instincts/pending"
+
+# Ensure directories exist
+$stateDir = Split-Path -Parent $STATE
+if (-not (Test-Path $stateDir)) {
+    New-Item -ItemType Directory -Path $stateDir -Force | Out-Null
+}
+if (-not (Test-Path $PENDING_DIR)) {
+    New-Item -ItemType Directory -Path $PENDING_DIR -Force | Out-Null
+}
+
+# Update session count
+if (Test-Path $STATE) {
+    try {
+        $stateObj = Get-Content $STATE -Raw | ConvertFrom-Json
+
+        $count = 0
+        if ($stateObj.journey -and $stateObj.journey.sessionCount) {
+            $count = [int]$stateObj.journey.sessionCount
+        }
+
+        $Timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+        if (-not $stateObj.journey) {
+            $stateObj | Add-Member -NotePropertyName "journey" -NotePropertyValue @{} -Force
+        }
+        $stateObj.journey.sessionCount = $count + 1
+        $stateObj.journey.lastSession = $Timestamp
+
+        $stateObj | ConvertTo-Json -Depth 10 | Set-Content $STATE -ErrorAction SilentlyContinue
+    } catch {
+        # Silently fail
+    }
+}
+
+exit 0


### PR DESCRIPTION
## Summary
- Add `observe.ps1` and `on_stop.ps1` for native Windows execution
- Update `hooks.json` to auto-detect OS (Msys/Cygwin → PowerShell, else bash)
- Works on all platforms without breaking existing Unix support

## Test plan
- [x] Tested on Windows 11 with Claude Code
- [x] Verified observations.jsonl captures prompts and tool usage
- [x] Verified identity.json session count increments on stop
- [ ] Should be tested on Linux/Mac to confirm bash still works